### PR TITLE
Added linker flags to create map files

### DIFF
--- a/CMake/Platform/mbedOS-GNU-C.cmake
+++ b/CMake/Platform/mbedOS-GNU-C.cmake
@@ -7,7 +7,7 @@ set(CMAKE_C_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
 set(CMAKE_C_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_C_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
 set(CMAKE_C_COMPILE_OBJECT        "<CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>")
-set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> <LINK_LIBRARIES> -Wl,--start-group -lnosys -lm -lc -lgcc -lnosys -lnosys -lm -lc -lgcc -lnosys -Wl,--end-group -o <TARGET>")
+set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> <LINK_LIBRARIES> -Wl,-Map,<TARGET>.map -Wl,--start-group -lnosys -lm -lc -lgcc -lnosys -lnosys -lm -lc -lgcc -lnosys -Wl,--end-group -o <TARGET>")
 
 
 set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -mcpu=cortex-m4 -mthumb -ffunction-sections -fdata-sections -Wall -Wextra -D__thumb2__")

--- a/CMake/Platform/mbedOS-GNU-CXX.cmake
+++ b/CMake/Platform/mbedOS-GNU-CXX.cmake
@@ -17,7 +17,7 @@ set(CMAKE_CXX_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1"
 set(CMAKE_CXX_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
 set(CMAKE_CXX_COMPILE_OBJECT        "<CMAKE_CXX_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>")
-set(CMAKE_CXX_LINK_EXECUTABLE       "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> <LINK_LIBRARIES> -Wl,--start-group -lnosys -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -lnosys -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group -o <TARGET>")
+set(CMAKE_CXX_LINK_EXECUTABLE       "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> <LINK_LIBRARIES> -Wl,-Map,<TARGET>.map -Wl,--start-group -lnosys -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -lnosys -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group -o <TARGET>")
 
 set(CMAKE_CXX_FLAGS_INIT "${_C_FAMILY_FLAGS_INIT} -fno-exceptions -fno-unwind-tables")
 set(CMAKE_CXX_FLAGS_DEBUG_INIT          "${CMAKE_CXX_FLAGS_INIT} -g")


### PR DESCRIPTION
The background of this patch is to enable people to see where flash
memory/SRAM is wasted so they can optimize memory usage.
