### PR TITLE
Remove nanostack from target.json

### DIFF
--- a/target.json
+++ b/target.json
@@ -33,7 +33,6 @@
     "lwip",
     "lwip-k64f",
     "eth-k64f",
-    "nanostack",
     "mbed"
   ],
   "toolchain": "CMake/toolchain.cmake",


### PR DESCRIPTION
nanostack removed because of:
https://github.com/ARMmbed/mbed-net-socket-abstract/issues/14

@bremoran would you please review the change.
