### PR TITLE
Add pin definitions to target.json

### DIFF
--- a/target.json
+++ b/target.json
@@ -19,7 +19,8 @@
     "gcc"
   ],
   "config": {
-    "mbed-os":{
+    "mbed-os": {},
+    "hardware": {
       "pins" : {
         "LED_RED" : "PTB22",
         "LED_GREEN" : "PTE26",

--- a/target.json
+++ b/target.json
@@ -73,6 +73,9 @@
     "armv7-m",
     "arm",
     "gcc",
+    "lwip",
+    "lwip-k64f",
+    "eth-k64f",
     "mbed"
   ],
   "toolchain": "CMake/toolchain.cmake",

--- a/target.json
+++ b/target.json
@@ -19,7 +19,46 @@
     "gcc"
   ],
   "config": {
-    "mbed-os": {}
+    "mbed-os":{
+      "pins" : {
+        "LED_RED" : "PTB22",
+        "LED_GREEN" : "PTE26",
+        "LED_BLUE" : "PTB21",
+        "LED1" : "LED_RED",
+        "LED2" : "LED_GREEN",
+        "LED3" : "LED_BLUE",
+        "LED4" : "LED_RED",
+        "SW2" : "PTC6",
+        "SW3" : "PTA4",
+        "USBTX" : "PTB17",
+        "USBRX" : "PTB16",
+        "D0" : "PTC16",
+        "D1" : "PTC17",
+        "D2" : "PTB9",
+        "D3" : "PTA1",
+        "D4" : "PTB23",
+        "D5" : "PTA2",
+        "D6" : "PTC2",
+        "D7" : "PTC3",
+        "D8" : "PTA0",
+        "D9" : "PTC4",
+        "D10" : "PTD0",
+        "D11" : "PTD2",
+        "D12" : "PTD3",
+        "D13" : "PTD1",
+        "D14" : "PTE25",
+        "D15" : "PTE24",
+        "I2C_SCL" : "D15",
+        "I2C_SDA" : "D14",
+        "A0" : "PTB2",
+        "A1" : "PTB3",
+        "A2" : "PTB10",
+        "A3" : "PTB11",
+        "A4" : "PTC10",
+        "A5" : "PTC11",
+        "DAC0_OUT" : "0xFEFE"
+      }
+    }
   },
   "similarTo": [
     "frdm-k64f",
@@ -33,9 +72,6 @@
     "armv7-m",
     "arm",
     "gcc",
-    "lwip",
-    "lwip-k64f",
-    "eth-k64f",
     "mbed"
   ],
   "toolchain": "CMake/toolchain.cmake",


### PR DESCRIPTION
These pin definitions will allow yotta-config to define pin names.