### PR TITLE
Added config for NVIC definitions

### DIFF
--- a/target.json
+++ b/target.json
@@ -19,7 +19,15 @@
     "gcc"
   ],
   "config": {
-    "mbed-os": {}
+    "mbed-os": {},
+    "cmsis": {
+        "nvic": {
+          "ram_vector_address": "0x1FFF0000",
+          "flash_vector_address": "0x0",
+          "user_irq_offset": 16,
+          "user_irq_number": 86
+        }
+    }
   },
   "similarTo": [
     "frdm-k64f",


### PR DESCRIPTION
This PR adds config entries for the following definitions:
```C
NVIC_NUM_VECTORS
NVIC_USER_IRQ_OFFSET
NVIC_RAM_VECTOR_ADDRESS
NVIC_FLASH_VECTOR_ADDRESS
```

when these changes are merged, the related PRs can be merged, so that `cmsis_nvic.*` files are moved from hw-specific `cmsis-core-*` modules to `cmsis-core`, to avoid duplication