### PR TITLE
Updated uvisor symbols in linker script

### DIFF
--- a/ld/K64FN1M0xxx12.ld
+++ b/ld/K64FN1M0xxx12.ld
@@ -56,29 +56,34 @@ SECTIONS
     /* ensure that uvisor bss is at the beginning of memory */
     .uvisor.bss (NOLOAD):
     {
-        /* protected uvisor SRAM starts here */
-        KEEP(*(.uvisor.bss.main))
-        KEEP(*(.uvisor.bss.stack))
+        . = ALIGN(32);
         __uvisor_bss_start = .;
-        *(.uvisor.bss*)
+
+        /* protected uvisor main bss */
+        . = ALIGN(32);
+        __uvisor_bss_main_start = .;
+        KEEP(*(.keep.uvisor.bss.main))
+        . = ALIGN(32);
+        __uvisor_bss_main_end = .;
+
+        /* protected uvisor secure boxes bss */
+        . = ALIGN(32);
+        __uvisor_bss_boxes_start = .;
+        KEEP(*(.keep.uvisor.bss.boxes))
+        . = ALIGN(32);
+        __uvisor_bss_boxes_end = .;
+
+        . = ALIGN(32);
         __uvisor_bss_end = .;
     } > RAM
-
-    .uvisor.data : AT(__uvisor_cfgtbl_end)
-    {
-        __uvisor_data_src = LOADADDR(.uvisor.data);
-
-        . = ALIGN(32);
-        __uvisor_data_start = .;
-        *(.uvisor.data)
-        . = ALIGN(32);
-        __uvisor_data_end = .;
-    } >RAM
 
     .text :
     {
         /* uVisor code and data */
+        . = ALIGN(4);
+        __uvisor_main_start = .;
         *(.uvisor.main)
+        __uvisor_main_end = .;
 
         *(.text*)
 
@@ -167,24 +172,27 @@ SECTIONS
 
     } >RAM AT>FLASH
 
-    /* put uvisor data flash section at the end of flash */
+    /* uvisor configuration data */
     .uvisor.secure :
     {
         . = ALIGN(32);
         __uvisor_secure_start = .;
-        KEEP(*(.uvisor.secure.keep))
-        *(.uvisor.secure)
+
+        /* uvisor secure boxes configuration tables */
         . = ALIGN(32);
-
         __uvisor_cfgtbl_start = .;
-        KEEP(*(.uvisor.cfgtbl_first*))
-        KEEP(*(.uvisor.cfgtbl*))
+        KEEP(*(.keep.uvisor.cfgtbl))
+        . = ALIGN(32);
         __uvisor_cfgtbl_end = .;
-    } >FLASH
 
-    .uvisor.end (NOLOAD): AT( LOADADDR(.uvisor.data) + SIZEOF(.uvisor.data) )
-    {
-        . = ALIGN(1024);
+        /* pointers to uvisor secure boxes configuration tables */
+        /* note: no further alignment here, we need to have the exact list of pointers */
+        __uvisor_cfgtbl_ptr_start = .;
+        KEEP(*(.keep.uvisor.cfgtbl_ptr_first))
+        KEEP(*(.keep.uvisor.cfgtbl_ptr))
+        __uvisor_cfgtbl_ptr_end = .;
+
+        . = ALIGN(32);
         __uvisor_secure_end = .;
     } >FLASH
 


### PR DESCRIPTION
This PR updates uVisor symbols in the gcc linker script for K64F.

**Note**: linker script already validated with @meriac in [previous internal PR](https://github.com/AlessandroA/target-frdm-k64f-gcc/pull/1)

Changelog:
- more consistent start/end symbols of protected regions for easier future porting
- protected SRAM and Flash regions removed -- they are not supported any more
- changed some of the names to adapt them to their new functionality
    - [SRAM] `.uvisor.bss` contains the uVisor protected .bss, containing
        - the uVisor stack and .bss
        - the stacks and contexts of the uVisor-protected secure boxes
    - [Flash] `.uvisor.main` contains the code and data for uVisor (in Flash, write-protected)
    - [Flash] `.uvisor.secure` contains the write- and read-protected configuration for the secure boxes
        - the configuration tables (one for each box)
        - a list of pointers to the configuration tables (for box enumeration at startup)