### PR TITLE
Config - test pins for mbed drivers (spi, i2c, serial)

### DIFF
--- a/target.json
+++ b/target.json
@@ -72,6 +72,22 @@
         "A4": "PTC10",
         "A5": "PTC11",
         "DAC0_OUT": "0xFEFE"
+      },
+      "test-pins": {
+        "spi": {
+          "mosi": "PTD2",
+          "miso": "PTD3",
+          "sclk": "PTD1",
+          "ssel": "PTD0"
+        },
+        "i2c": {
+          "sda": "PTE25",
+          "scl": "PTE24"
+        },
+        "serial": {
+          "tx": "PTC17",
+          "rx": "PTD2"
+        }
       }
     }
   },


### PR DESCRIPTION
I would like to remove the macros in tests/examples in mbed-drivers, mbed-hal.

```
#if defined(TARGET_K64F)
#define TEST_MOSI_PIN PTD2
#define TEST_MISO_PIN PTD3
#define TEST_SCLK_PIN PTD1
#define TEST_CS_PIN   PTD0
#else
#error Target not supported
#endif
```

which can be turn into

```
#if !defined(YOTTA_CFG_MBED_DRIVERS_TEST_SPI_MISO) || !defined(YOTTA_CFG_MBED_DRIVERS_TEST_SPI_MOSI) || \
    !defined(YOTTA_CFG_MBED_DRIVERS_TEST_SPI_SCLK) || !defined(YOTTA_CFG_MBED_DRIVERS_TEST_SPI_SSEL)
#error Your target is outdated, update! or define these pins in yotta config
#endif
```

@autopulated @bogdanm @bremoran 