### PR TITLE
Added uVisor-supported config flag

### DIFF
--- a/target.json
+++ b/target.json
@@ -34,6 +34,9 @@
         "user_irq_number": 86
       }
     },
+    "uvisor": {
+      "present": 1
+    },
     "hardware": {
       "pins": {
         "LED_RED": "PTB22",


### PR DESCRIPTION
The flag means uVisor is supported on the target, not that it is enabled.

@bogdanm 
@meriac 